### PR TITLE
hard code local variables A-E instead of using locals()

### DIFF
--- a/vnpy_spreadtrading/base.py
+++ b/vnpy_spreadtrading/base.py
@@ -383,7 +383,16 @@ class SpreadData:
 
     def parse_formula(self, formula: str, data: Dict[str, float]) -> Any:
         """"""
-        locals().update(data)
+        if "A" in data:
+            A = data["A"]
+        if "B" in data:
+            B = data["B"]
+        if "C" in data:
+            C = data["C"]
+        if "D" in data:
+            D = data["D"]
+        if "E" in data:
+            E = data["E"]
         value = eval(formula)
         return value
 

--- a/vnpy_spreadtrading/ui/widget.py
+++ b/vnpy_spreadtrading/ui/widget.py
@@ -877,8 +877,7 @@ class SpreadDataDialog(QtWidgets.QDialog):
 
     def check_formula(self, formula: str) -> bool:
         """"""
-        data: dict = {variable: 1 for variable in "ABCDE"}
-        locals().update(data)
+        A = B = C = D = E = 1
         try:
             result: Any = eval(formula)
             return True


### PR DESCRIPTION
根据https://peps.python.org/pep-0667 ，在Python 3.13版本locals()只会返回一个快照，对其返回值作修改不会改变ABCDE这些变量，和formula相关的计算均会出错。建议直接使用A-E变量。

The locals() function will act the same as it does now for class and modules scopes. For function scopes it will return an instantaneous snapshot of the underlying frame.f_locals rather than implicitly refreshing a single shared dictionary cached on the frame object.